### PR TITLE
Improved extendibility with new formats

### DIFF
--- a/src/Kassner/LogParser/Factory.php
+++ b/src/Kassner/LogParser/Factory.php
@@ -7,7 +7,6 @@ class Factory
 
     public static function create()
     {
-        return new LogParser();
+        return new LogParser(LogParser::getDefaultFormat());
     }
-
 }

--- a/src/Kassner/LogParser/LogParser.php
+++ b/src/Kassner/LogParser/LogParser.php
@@ -38,6 +38,11 @@ class LogParser
         $this->setFormat($format ?: self::getDefaultFormat());
     }
 
+    public function addPattern($placeholder, $pattern)
+    {
+        $this->patterns[$placeholder] = $pattern;
+    }
+
     public function setFormat($format)
     {
         // strtr won't work for "complex" header patterns

--- a/src/Kassner/LogParser/LogParser.php
+++ b/src/Kassner/LogParser/LogParser.php
@@ -4,7 +4,6 @@ namespace Kassner\LogParser;
 
 class LogParser
 {
-
     protected $pcreFormat, $patterns = array(
             '%%' => '(?P<percent>\%)',
             '%a' => '(?P<remoteIp>(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?))',
@@ -27,9 +26,16 @@ class LogParser
             '\%\{(?P<name>[a-zA-Z]+)(?P<name2>[-]?)(?P<name3>[a-zA-Z]+)\}i' => '(?P<Header\\1\\3>.*?)',
     );
 
-    public function __construct($format = '%h %l %u %t "%r" %>s %b')
+    static protected $defaultFormat = '%h %l %u %t "%r" %>s %b';
+
+    static public function getDefaultFormat()
     {
-        $this->setFormat($format);
+        return self::$defaultFormat;
+    }
+
+    public function __construct($format = null)
+    {
+        $this->setFormat($format ?: self::getDefaultFormat());
     }
 
     public function setFormat($format)


### PR DESCRIPTION
I've added a bit of code to improve the extendibility of LogParser. Callers can now add own patterns with the `addPattern` method. Also, derived classes can override the constructor without knowing the default format – they can get the default format with `LogParser::getDefaultFormat()` now.