### PR TITLE
Parse invalid request strings like in logline

### DIFF
--- a/src/Kassner/LogParser/LogParser.php
+++ b/src/Kassner/LogParser/LogParser.php
@@ -15,7 +15,7 @@ class LogParser
         '%l' => '(?P<logname>(?:-|[\w-]+))',
         '%m' => '(?P<requestMethod>OPTIONS|GET|HEAD|POST|PUT|DELETE|TRACE|CONNECT|PATCH|PROPFIND)',
         '%p' => '(?P<port>\d+)',
-        '%r' => '(?P<request>(?:(?:[A-Z]+) .+? HTTP/1.(?:0|1))|-|)',
+        '%r' => '(?P<request>(?:(?:[A-Z]+) .+? HTTP/1.(?:0|1))|-|(?:[^\s]+)|)',
         '%t' => '\[(?P<time>\d{2}/(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)/\d{4}:\d{2}:\d{2}:\d{2} (?:-|\+)\d{4})\]',
         '%u' => '(?P<user>(?:-|[\w-]+))',
         '%U' => '(?P<URL>.+?)',

--- a/tests/Kassner/Tests/LogParser/Apache/CombinedTest.php
+++ b/tests/Kassner/Tests/LogParser/Apache/CombinedTest.php
@@ -65,6 +65,17 @@ class CombinedTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('0', $entry->sentBytes);
         $this->assertEquals('-', $entry->HeaderReferer);
         $this->assertEquals('-', $entry->HeaderUserAgent);
+
+        $entry = $parser->parse('169.229.3.91 - - [05/Jun/2016:15:26:51 +0200] "\x99\xf3\x0fF\xd9\xdde\xba\x97" 501 308 "-" "-"');
+        $this->assertEquals('169.229.3.91', $entry->host);
+        $this->assertEquals('-', $entry->logname);
+        $this->assertEquals('-', $entry->user);
+        $this->assertEquals('05/Jun/2016:15:26:51 +0200', $entry->time);
+        $this->assertEquals('\x99\xf3\x0fF\xd9\xdde\xba\x97', $entry->request);
+        $this->assertEquals('501', $entry->status);
+        $this->assertEquals('308', $entry->sentBytes);
+        $this->assertEquals('-', $entry->HeaderReferer);
+        $this->assertEquals('-', $entry->HeaderUserAgent);
     }
 
 }


### PR DESCRIPTION
In my apache 2.4 access logs, i have found several invalid "request" strings, which do not match the normal flow.

example: 

`169.229.3.91 - - [05/Jun/2016:15:26:51 +0200] "\x99\xf3\x0fF\xd9\xdde\xba\x97" 501 308 "-" "-"`