### PR TITLE
add createEntry method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /vendor/
 /nbproject/
 .DS_Store
+.idea
 composer.lock

--- a/src/Kassner/LogParser/LogParser.php
+++ b/src/Kassner/LogParser/LogParser.php
@@ -101,7 +101,7 @@ class LogParser
             throw new FormatException($line);
         }
 
-        $entry = new \stdClass();
+        $entry = $this->createEntry();
 
         foreach (array_filter(array_keys($matches), 'is_string') as $key) {
             if ('time' === $key && true !== $stamp = strtotime($matches[$key])) {
@@ -112,6 +112,14 @@ class LogParser
         }
 
         return $entry;
+    }
+
+    /**
+     * @return \stdClass
+     */
+    protected function createEntry()
+    {
+        return new \stdClass();
     }
 
     /**


### PR DESCRIPTION
add `createEntry` method.

This is necessary if we want to override the `stdClass` object to another object with more extensive functionality.

Wish:
replace the `stdClass` object to an object with magic methods `__get`/`__set`.