### PR TITLE
Add support for HTTP2 requests

### DIFF
--- a/src/Kassner/LogParser/LogParser.php
+++ b/src/Kassner/LogParser/LogParser.php
@@ -19,7 +19,7 @@ class LogParser
         '%l' => '(?P<logname>(?:-|[\w-]+))',
         '%m' => '(?P<requestMethod>OPTIONS|GET|HEAD|POST|PUT|DELETE|TRACE|CONNECT|PATCH|PROPFIND)',
         '%p' => '(?P<port>\d+)',
-        '%r' => '(?P<request>(?:(?:[A-Z]+) .+? HTTP/1.(?:0|1))|-|)',
+        '%r' => '(?P<request>(?:(?:[A-Z]+) .+? HTTP/[1-2].(?:0|1))|-|)',
         '%t' => '\[(?P<time>\d{2}/(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)/\d{4}:\d{2}:\d{2}:\d{2} (?:-|\+)\d{4})\]',
         '%u' => '(?P<user>(?:-|[\w-\.]+))',
         '%U' => '(?P<URL>.+?)',


### PR DESCRIPTION
Http request pattern can't handle log records from http2.0 requests. 