### PR TITLE
Send Bytes can optionally be '-'.

### DIFF
--- a/src/LogParser.php
+++ b/src/LogParser.php
@@ -35,7 +35,7 @@ final class LogParser
         '%>s' => '(?P<status>\d{3}|-)',
         '%b' => '(?P<responseBytes>(\d+|-))',
         '%T' => '(?P<requestTime>(\d+\.?\d*))',
-        '%O' => '(?P<sentBytes>[0-9]+)',
+        '%O' => '(?P<sentBytes>[0-9]+|\-)',
         '%I' => '(?P<receivedBytes>[0-9]+)',
         '\%\{(?P<name>[a-zA-Z]+)(?P<name2>[-]?)(?P<name3>[a-zA-Z]+)\}i' => '(?P<Header\\1\\3>.*?)',
         '%D' => '(?P<timeServeRequest>[0-9]+)',


### PR DESCRIPTION
Instead of an integer, if no response is returned the sendBytes value can also be a simple dash `-`.