### PR TITLE
Add support for %{format}p format string.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Here is the full list of [log format strings](https://httpd.apache.org/docs/2.2/
 | Y | %{Foobar}i | *Header | The contents of Foobar: header line(s) in the request sent to the server. Changes made by other modules (e.g. mod_headers) affect this. If you're interested in what the request header was prior to when most modules would have modified it, use mod_setenvif to copy the header into an internal environment variable and log that value with the %{VARNAME}e described above. |
 | N | %{Foobar}n | - | The contents of note Foobar from another module. |
 | N | %{Foobar}o | - | The contents of Foobar: header line(s) in the reply. |
-| N | %{format}p | - | The canonical port of the server serving the request or the server's actual port or the client's actual port. Valid formats are canonical, local, or remote. |
+| Y | %{format}p | *Port | The canonical port of the server serving the request or the server's actual port or the client's actual port. Valid formats are canonical, local, or remote. |
 | N | %{format}P | - | The process ID or thread id of the child that serviced the request. Valid formats are pid, tid, and hextid. hextid requires APR 1.2.0 or higher. |
 | N | %{format}t | - | The time, in the form given by format, which should be in strftime(3) format. (potentially localized) (This directive was %c in late versions of Apache 1.3, but this conflicted with the historical ssl %{var}c syntax.) |
 

--- a/src/LogParser.php
+++ b/src/LogParser.php
@@ -26,6 +26,7 @@ final class LogParser
         '%m' => '(?P<requestMethod>OPTIONS|GET|HEAD|POST|PUT|DELETE|TRACE|CONNECT|PATCH|PROPFIND)',
         '%H' => '(?P<requestProtocol>HTTP/(1\.0|1\.1|2\.0))',
         '%p' => '(?P<port>\d+)',
+        '\%\{(local|canonical|remote)\}p' => '(?P<\\1Port>\d+)',
         '%r' => '(?P<request>(?:(?:[A-Z]+) .+? HTTP/(1\.0|1\.1|2\.0))|-|)',
         '%t' => '\[(?P<time>\d{2}/(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)/\d{4}:\d{2}:\d{2}:\d{2} (?:-|\+)\d{4})\]',
         '%u' => '(?P<user>(?:-|[\w\-\.]+))',

--- a/tests/Format/PortNumbersTest.php
+++ b/tests/Format/PortNumbersTest.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Kassner\LogParser\Tests\Format;
+
+use Kassner\LogParser\LogParser;
+
+/**
+ * @description Test the various port number format strings %p %{local}p, %{remote}p and %{canonical}p
+ */
+class PortNumbersTest extends \PHPUnit\Framework\TestCase
+{
+    protected $parser = null;
+
+    protected function setUp(): void
+    {
+        $this->parser = new LogParser();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->parser = null;
+    }
+
+    /**
+     * @dataProvider successProvider
+     */
+    public function testPortSuccess($line)
+    {
+        $this->parser->setFormat('%p');
+        $entry = $this->parser->parse($line);
+        $this->assertEquals($line, $entry->port);
+	$this->assertObjectNotHasAttribute('localPort', $entry);
+	$this->assertObjectNotHasAttribute('remotePort', $entry);
+	$this->assertObjectNotHasAttribute('canonicalPort', $entry);
+    }
+
+    /**
+     * @dataProvider invalidProvider
+     */
+    public function testPortInvalid($line)
+    {
+        $this->parser->setFormat('%p');
+        $this->expectException(\Kassner\LogParser\FormatException::class);
+        $this->parser->parse($line);
+    }
+
+    /**
+     * @dataProvider successProvider
+     */
+    public function testLocalPortSuccess($line)
+    {
+        $this->parser->setFormat('%{local}p');
+        $entry = $this->parser->parse($line);
+        $this->assertEquals($line, $entry->localPort);
+	$this->assertObjectNotHasAttribute('port', $entry);
+	$this->assertObjectNotHasAttribute('remotePort', $entry);
+	$this->assertObjectNotHasAttribute('canonicalPort', $entry);
+    }
+
+    /**
+     * @dataProvider invalidProvider
+     */
+    public function testLocalPortInvalid($line)
+    {
+        $this->parser->setFormat('%{local}p');
+        $this->expectException(\Kassner\LogParser\FormatException::class);
+        $this->parser->parse($line);
+    }
+
+    /**
+     * @dataProvider successProvider
+     */
+    public function testRemotePortSuccess($line)
+    {
+        $this->parser->setFormat('%{remote}p');
+        $entry = $this->parser->parse($line);
+        $this->assertEquals($line, $entry->remotePort);
+	$this->assertObjectNotHasAttribute('port', $entry);
+	$this->assertObjectNotHasAttribute('localPort', $entry);
+	$this->assertObjectNotHasAttribute('canonicalPort', $entry);
+    }
+
+    /**
+     * @dataProvider invalidProvider
+     */
+    public function testRemotePortInvalid($line)
+    {
+        $this->parser->setFormat('%{remote}p');
+        $this->expectException(\Kassner\LogParser\FormatException::class);
+        $this->parser->parse($line);
+    }
+    /**
+     * @dataProvider successProvider
+     */
+    public function testCanonicalPortSuccess($line)
+    {
+        $this->parser->setFormat('%{canonical}p');
+        $entry = $this->parser->parse($line);
+        $this->assertEquals($line, $entry->canonicalPort);
+	$this->assertObjectNotHasAttribute('port', $entry);
+	$this->assertObjectNotHasAttribute('localPort', $entry);
+	$this->assertObjectNotHasAttribute('remotePort', $entry);
+    }
+
+    /**
+     * @dataProvider invalidProvider
+     */
+    public function testCanonicalPortInvalid($line)
+    {
+        $this->parser->setFormat('%{canonical}p');
+        $this->expectException(\Kassner\LogParser\FormatException::class);
+        $this->parser->parse($line);
+    }
+
+    public function successProvider()
+    {
+        return [
+            ['443'],
+            ['80'],
+            ['123423']
+        ];
+    }
+
+    public function invalidProvider()
+    {
+        return [
+            [''],
+            ['Nan'],
+            ['+Inf'],
+            ['1.6e-19']
+        ];
+    }
+}


### PR DESCRIPTION
This adds support for the %{format}p format string. Adds a test to confirm
that the format string functions correctly. The test also checks the "%p" option
too. Also update the README to reflect the new suported format.