### PR TITLE
Update PCRE pattern after LogParser::addPattern()

### DIFF
--- a/tests/CustomPatternTest.php
+++ b/tests/CustomPatternTest.php
@@ -50,4 +50,22 @@ class CustomPatternTest extends IpAddressProvider
         $entry = $this->parser->parse('192.168.1.20 2001:aaaa:bbbb::cc00 "GET / HTTP/1.1"');
         $this->assertEquals('2001:aaaa:bbbb::cc00', $entry->loadBalancer);
     }
+
+    public function testAddPatternBeforeSetFormat()
+    {
+        $this->parser->addPattern('%Y', '(?P<test>[0-9]+)');
+        $this->parser->setFormat('%Y');
+
+        $entry = $this->parser->parse('123');
+        $this->assertEquals('123', $entry->test);
+    }
+
+    public function testAddPatternAfterSetFormat()
+    {
+        $this->parser->setFormat('%Y');
+        $this->parser->addPattern('%Y', '(?P<test>[0-9]+)');
+
+        $entry = $this->parser->parse('123');
+        $this->assertEquals('123', $entry->test);
+    }
 }


### PR DESCRIPTION
This allows `addPattern` and `setFormat` to be called in any order. No user should expect performance issues unless they're re-using/re-creating the LogParser instance at every row, which is somewhat counter intuitive.