### PR TITLE
Allow `@` (at sign) when parsing remote user format string.

### DIFF
--- a/src/LogParser.php
+++ b/src/LogParser.php
@@ -32,7 +32,7 @@ final class LogParser
         '\%\{(local|canonical|remote)\}p' => '(?P<\\1Port>\d+)',
         '%r' => '(?P<request>(?:(?:[A-Z]+) .+? HTTP/(1\.0|1\.1|2\.0))|-|)',
         '%t' => '\[(?P<time>\d{2}/(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)/\d{4}:\d{2}:\d{2}:\d{2} (?:-|\+)\d{4})\]',
-        '%u' => '(?P<user>(?:-|[\w\-\.]+))',
+        '%u' => '(?P<user>(?:-|[\w\-\.@]+))',
         '%U' => '(?P<URL>.+?)',
         '%v' => '(?P<serverName>([a-zA-Z0-9]+)([a-z0-9.-]*))',
         '%V' => '(?P<canonicalServerName>([a-zA-Z0-9]+)([a-z0-9.-]*))',

--- a/tests/Format/UserTest.php
+++ b/tests/Format/UserTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Kassner\LogParser\Tests\Format;
+
+use Kassner\LogParser\LogParser;
+
+/**
+ * @format %u
+ *
+ * @description The remote user
+ */
+class UserTest extends \PHPUnit\Framework\TestCase
+{
+    protected $parser;
+
+    protected function setUp(): void
+    {
+        $this->parser = new LogParser();
+        $this->parser->setFormat('%u');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->parser = null;
+    }
+
+    /**
+     * @dataProvider successProvider
+     */
+    public function testSuccess($line)
+    {
+        $entry = $this->parser->parse($line);
+        $this->assertEquals($line, $entry->user);
+    }
+
+    /**
+     * @dataProvider invalidProvider
+     */
+    public function testInvalid($line)
+    {
+        $this->expectException(\Kassner\LogParser\FormatException::class);
+        $this->parser->parse($line);
+    }
+
+    public function successProvider()
+    {
+        return [
+            ['-'],
+            ['.'],
+            ['@'],
+            ['abc'],
+            ['abc_def'],
+            ['abc-def'],
+            ['abc.def'],
+            ['abc.def-ghi'],
+            ['abc-def@ghi.jkl'],
+        ];
+    }
+
+    public function invalidProvider()
+    {
+        return [
+            ['abc '],
+            [' '],
+            ['!'],
+            ['a:b'],
+            ['<abc>'],
+            ['a/b'],
+        ];
+    }
+}


### PR DESCRIPTION
This adds `@` (at sign) to the allowable characters when parsing the remote user format string (`%u`).